### PR TITLE
Remove call to Start() from the testserver docs

### DIFF
--- a/testserver/testserver.go
+++ b/testserver/testserver.go
@@ -27,9 +27,6 @@
 //      if err != nil {
 //        t.Fatal(err)
 //      }
-//      if err := ts.Start(); err != nil {
-//        t.Fatal(err)
-//      }
 //      defer ts.Stop()
 //
 //      url := ts.PGURL()


### PR DESCRIPTION
This PR aims to update the docs in regards to how the test server is used. The is an open issue that reports the details on
https://github.com/cockroachdb/cockroach-go/issues/98